### PR TITLE
Suspend GH Action for Serverless

### DIFF
--- a/.github/workflows/serverless-mail-handler.yml
+++ b/.github/workflows/serverless-mail-handler.yml
@@ -3,9 +3,7 @@ on:
     paths:
       - 'serverless/mail-handler/**'
     branches:
-      - develop
-      - staging
-      - main
+      - temporary_bypass
 jobs:
   deploy:
     name: deploy


### PR DESCRIPTION
Having configured Serverless.com to integrate with Github and manage deployment, we no longer need to rely on Github Actions to trigger a serverless deployment on lambda change. 

Moving forward, code deployments will remain in Github Actions (s3 sync & cloudfront invalidation). Serverless functions will be deployed through integration with Serverless.com. Infrastructure changes will be deployed through Terraform Cloud. 